### PR TITLE
Quick-and-dirty fix for Promise error invalid metric name

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,6 +117,9 @@ class PrometheusApp extends Homey.App {
         else if(typeof value === 'string')
         	return; // Strings are not yet mapped
 
+        // Fix sub-components in names (replace . with _)
+        statename = statename.replace('.', '_');
+
         console.log("State changed for " + devId + ", " + statename);
         let key = "homey_device_" + statename;
         if(!(key in gauge_device)) {


### PR DESCRIPTION
Replace sub-component names (.) in device names with safe char (_), allowing clean start of metric server if Homey contains such devices.