### PR TITLE
Fix val check for boolean capabilities

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,7 +157,7 @@ class PrometheusApp extends Homey.App {
                 var capInst = null;
                 let self = this;
                 function onCapChg(val) {
-                    if(val) {
+                    if(val !== null && val !== undefined) {
                         //console.log(" dev cap " + dev.name + " "+ sn + " is " + val);
                         self.reportState(devId, sn, val);
                     }


### PR DESCRIPTION
Boolean capabilities with val === false would also be caught by conditional to check if value should be reported or not.

E.g contact_alarms would indefinitely get stuck at 1 if they ever get triggered since monitoring that report state.

Solves #10, #9